### PR TITLE
Replace DiffResults with LogDensityProblems evaluation.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,9 @@ matrix:
 # uncomment the following lines for debugging Documenter.jl
 # env:
 #   - DOCUMENTER_DEBUG=true
+before_script:
+  # install unregistered dependencies (FIXME remove when registered)
+  - julia -e 'using Pkg; pkg"add https://github.com/tpapp/TransformVariables.jl.git"; pkg"add https://github.com/tpapp/LogDensityProblems.jl"'
 # uncomment the following lines to override the default test script
 # script:
 #   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi

--- a/Project.toml
+++ b/Project.toml
@@ -6,13 +6,14 @@ version = "0.1.0"
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
-DiffResults = "163ba53b-c6d8-5494-b064-1a9d43ac40c5"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+LogDensityProblems = "025064c8-8453-11e8-27bf-e54b7298189f"
 Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsFuns = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
+TransformVariables = "eb4f743c-8036-11e8-1c4c-19fb1cbfc623"
 
 [extras]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"

--- a/docs/src/lowlevel.md
+++ b/docs/src/lowlevel.md
@@ -27,7 +27,7 @@ The following are used consistently for variables:
 
 # Low-level building blocks
 
-This is documented only for package developers. These are not part of the public API, if you are using them you should reconsider or file an issue.
+This is documented only for developers. These are not part of the public API, if you are using them you should reconsider or file an issue.
 
 ## Hamiltonian and leapfrog
 
@@ -40,7 +40,6 @@ rand_phasepoint
 neg_energy
 get_p♯
 leapfrog
-is_valid_ℓq
 ```
 
 ## Finding initial stepsize ``\epsilon``

--- a/src/DynamicHMC.jl
+++ b/src/DynamicHMC.jl
@@ -4,16 +4,16 @@ import Base: rand, length, show
 
 using ArgCheck: @argcheck
 using DataStructures: counter
-import DiffResults
 using DocStringExtensions: SIGNATURES, FIELDS
 using LinearAlgebra
 using LinearAlgebra: checksquare
+using LogDensityProblems:
+    AbstractLogDensityProblem, dimension, logdensity, ValueGradient, logdensity
 using Parameters: @unpack
-using Random: AbstractRNG
+using Random: AbstractRNG, randn
 using Statistics: cov, mean, median, middle, quantile, var
-import StatsFuns: logaddexp
+using StatsFuns: logaddexp
 
-include("utilities.jl")
 include("hamiltonian.jl")
 include("stepsize.jl")
 include("buildingblocks.jl")

--- a/src/buildingblocks.jl
+++ b/src/buildingblocks.jl
@@ -3,6 +3,19 @@ export
     get_acceptance_rate, get_steps
 
 
+# utilities
+
+"""
+$(SIGNATURES)
+
+Random boolean which is `true` with the given probability `prob`.
+
+**All random numbers in this library are obtained from this function.**
+"""
+rand_bool(rng::AbstractRNG, prob::T) where {T <: AbstractFloat} =
+    rand(rng, T) ≤ prob
+
+
 # abstract trajectory interface
 
 """

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -1,9 +1,0 @@
-"""
-    $SIGNATURES
-
-Random boolean which is `true` with the given probability `prob`.
-
-All random numbers in this library are obtained from this function.
-"""
-rand_bool(rng::AbstractRNG, prob::T) where {T <: AbstractFloat} =
-    rand(rng, T) ≤ prob

--- a/test/test-normal-mcmc.jl
+++ b/test/test-normal-mcmc.jl
@@ -107,7 +107,7 @@ end
                    5.57947 -0.0540131 1.78163 1.73862 -2.99741 3.6118 10.215 9.60671;
                    7.28634 1.79718 -0.0821483 2.55874 -1.95031 5.22626 9.60671 11.5554])
     for ℓ in [ℓ0, ℓ1, ℓ2, ℓ3]
-        sample, nuts = NUTS_init_tune_mcmc(RNG, ℓ, length(ℓ), 1000;
+        sample, nuts = NUTS_init_tune_mcmc(RNG, DistributionLogDensity(ℓ), length(ℓ), 1000;
                                            report = ReportSilent())
         @test EBFMI(sample) ≥ 0.3
         @test maximum(R̂(nuts, 1000, 3)) ≤ 1.05
@@ -121,7 +121,7 @@ end
     for _ in 1:100
         K = rand(2:10)
         ℓ = MvNormal(randn(K), Matrix(rand_Σ(K)))
-        sample, nuts = NUTS_init_tune_mcmc(RNG, ℓ, K, 1000;
+        sample, nuts = NUTS_init_tune_mcmc(RNG, DistributionLogDensity(ℓ), K, 1000;
                                            report = ReportSilent())
         @test EBFMI(sample) ≥ 0.3
         @test maximum(R̂(nuts, 1000, 3)) ≤ 1.05

--- a/test/test-reporting.jl
+++ b/test/test-reporting.jl
@@ -1,8 +1,8 @@
 @testset "reporting" begin
-    ℓ = MvNormal(zeros(3), ones(3))
+    ℓ = DistributionLogDensity(MvNormal, 3)
     @color_output false begin
         output = @capture_err begin
-            sample, nuts = NUTS_init_tune_mcmc(RNG, ℓ, length(ℓ), 1000;
+            sample, nuts = NUTS_init_tune_mcmc(RNG, ℓ, dimension(ℓ), 1000;
                                                report = ReportIO())
         end
     end

--- a/test/test-sample-normal.jl
+++ b/test/test-sample-normal.jl
@@ -32,7 +32,7 @@ end
 @testset "unit normal simple HMC" begin
     # just testing leapfrog
     K = 2
-    ℓ = MvNormal(zeros(K), ones(K))
+    ℓ = DistributionLogDensity(MvNormal, K)
     q = rand(ℓ)
     H = Hamiltonian(ℓ, GaussianKE(Diagonal(ones(K))))
     qs = sample_HMC(H, q, 10000)
@@ -47,7 +47,7 @@ end
         K = rand(2:8)
         N = 10000
         Σ = rand_Σ(K)
-        ℓ = MvNormal(randn(K), Matrix(Σ))
+        ℓ = DistributionLogDensity(MvNormal(randn(K), Matrix(Σ)))
         q = rand(ℓ)
         H = Hamiltonian(ℓ, GaussianKE(Σ))
         qs = Array{Float64}(undef, N, K)
@@ -65,7 +65,7 @@ end
 
 @testset "tuning building blocks" begin
     K = 4
-    ℓ = MvNormal(zeros(K), fill(2.0, K))
+    ℓ = DistributionLogDensity(MvNormal(zeros(K), fill(2.0, K)))
     sampler = NUTS_init(RNG, ℓ, K)
     tuner = StepsizeTuner(100)
     sampler2 = tune(sampler, tuner)
@@ -77,7 +77,7 @@ end
 @testset "transition accessors and consistency checks" begin
     K = 2
     Σ = rand_Σ(K)
-    ℓ = MvNormal(randn(K), Matrix(Σ))
+    ℓ = DistributionLogDensity(MvNormal(randn(K), Matrix(Σ)))
     q = rand(ℓ)
     H = Hamiltonian(ℓ, GaussianKE(Σ))
     ϵ = 0.5

--- a/test/test-stepsize.jl
+++ b/test/test-stepsize.jl
@@ -109,7 +109,7 @@ end
 
 @testset "error for non-finite initial density" begin
     p = InitialStepsizeSearch()
-    H = Hamiltonian((x)->DiffResults.DiffResult(-Inf, ([0.0], )), GaussianKE(1))
+    H = Hamiltonian(FunctionLogDensity(ValueGradient(-Inf, [0.0])), GaussianKE(1))
     z = DynamicHMC.phasepoint_in(H, [1.0], [1.0])
     @test_throws DomainError find_initial_stepsize(p, H, z)
 end


### PR DESCRIPTION
Remove infinite value validation, since ValueGradient checks for that.

Use wrapper types in tests.