### PR TITLE
Fix divergence statistics for singular node.

### DIFF
--- a/src/buildingblocks.jl
+++ b/src/buildingblocks.jl
@@ -180,7 +180,7 @@ end
 
 Empty divergence statistic (for initial node).
 """
-divergence_statistic() = DivergenceStatistic(false, 0.0, 0)
+divergence_statistic() = DivergenceStatistic(false, 0.0, 1)
 
 """
     divergence_statistic(isdivergent, Δ)


### PR DESCRIPTION
When the immediate neighbor is divergent (no tree is built), we divide by 0. May fix #38.