### PR TITLE
WIP: Non-allocating trajectories and sampling.

### DIFF
--- a/src/DynamicHMC.jl
+++ b/src/DynamicHMC.jl
@@ -1,23 +1,27 @@
 module DynamicHMC
 
-import Base: rand, length, show
+# import Base: rand, length, show
 
-using ArgCheck: @argcheck
-using DataStructures: counter
-using DocStringExtensions: FIELDS, SIGNATURES, TYPEDEF
-using LinearAlgebra
-using LinearAlgebra: checksquare
-using LogDensityProblems: dimension, logdensity, ValueGradient, logdensity
-using Parameters: @unpack
-using Random: AbstractRNG, randn, Random
-using Statistics: cov, mean, median, middle, quantile, var
-using StatsFuns: logaddexp
+# using ArgCheck: @argcheck
+# using DataStructures: counter
+# using DocStringExtensions: FIELDS, SIGNATURES, TYPEDEF
+# using LinearAlgebra
+# using LinearAlgebra: checksquare
+# using LogDensityProblems: dimension, logdensity, ValueGradient, logdensity
+# using Parameters: @unpack
+# using Random: AbstractRNG, randn, Random
+# using Statistics: cov, mean, median, middle, quantile, var
+# using StatsFuns: logaddexp
 
-include("hamiltonian.jl")
-include("stepsize.jl")
-include("buildingblocks.jl")
-include("reporting.jl")
-include("sampler.jl")
-include("diagnostics.jl")
+# include("hamiltonian.jl")
+# include("stepsize.jl")
+# include("buildingblocks.jl")
+# include("reporting.jl")
+# include("sampler.jl")
+# include("diagnostics.jl")
+
+# NEW CODE
+
+include("trajectories.jl")
 
 end # module

--- a/src/trajectories.jl
+++ b/src/trajectories.jl
@@ -1,0 +1,292 @@
+module Trajectories
+
+export Buffers, initialize_buffers!, Visited, initialize_visited!, random_direction_flags,
+    build_adjacent!, transition!
+
+using ArgCheck: @argcheck
+using DocStringExtensions: FIELDS, FUNCTIONNAME, SIGNATURES, TYPEDEF
+using StatsFuns: logaddexp
+using Parameters: @unpack
+
+####
+#### utilities
+####
+
+"""
+Upper bound for the MAX_DEPTH supported by these routines.
+
+This is required because we use an integer to store the bits.
+"""
+const SUPPORTED_MAX_DEPTH = 32
+
+"""
+$(SIGNATURES)
+
+Random Metropolis acceptance with log proposal ratio `Δ`.
+
+Will only generate a random number if necessary.
+"""
+accept_Δ(rng, Δ) = Δ ≥ 0 || rand(rng) < exp(Δ)
+
+"""
+$(SIGNATURES)
+
+Generate random direction flags, returned as an integer.
+
+`max_depth` is limited to [`SUPPORTED_MAX_DEPTH`](@ref).
+"""
+function random_direction_flags(rng, max_depth)
+    @argcheck 0 < max_depth ≤ SUPPORTED_MAX_DEPTH
+    rand(rng, UInt32)
+end
+
+####
+#### exposed API for trajectories
+####
+
+"""
+$(FUNCTIONNAME)(z, trajectory, is_forward)
+
+Update phasepoint `z` on `trajectory`, moving forward or backward as determined by the
+direction argument. Modifies `z`, returned value is unused.
+
+Buffers for `z` can be allocated with [`empty_z`](@ref).
+"""
+function move! end
+
+"""
+$(FUNCTIONNAME)(trajectory, z)
+
+Return the log probability of `z` on `trajectory`.
+"""
+function log_probability(trajectory, z) end
+
+"""
+$(FUNCTIONNAME)(p♯, trajectory, z)
+
+Calculate `p♯`, a statistic related to `z`, useful for evaluating turning, on the
+`trajectory`.
+
+Buffers for `p♯` can be allocated with [`empty_p♯`](@ref).
+"""
+function get_p♯! end
+
+"""
+$(FUNCTIONNAME)(ρ, trajectory, z)
+
+Calculate `ρ`, a statistic related to `z`, useful for evaluating turning, on the
+`trajectory`. This is used for leafs on the tree, and then added with [`add_ρ!`](@ref).
+
+Buffers for `ρ` can be allocated with [`empty_ρ`](@ref).
+"""
+function get_ρ!(ρ, trajectory, z) end
+
+"""
+$(FUNCTIONNAME)(ρ, trajectory, ρ′)
+
+Combine `ρ` and `ρ′` into `ρ`, overwriting the latter.
+
+Buffers for `ρ` can be allocated with [`empty_ρ`](@ref).
+"""
+add_ρ!(ρ, trajectory, ρ′) = ρ .= ρ′
+
+"""
+$(FUNCTIONNAME)(trajectory)
+
+Allocate a mutable buffer for phasepoints `z`.
+"""
+function empty_z end
+
+"""
+$(FUNCTIONNAME)(trajectory)
+
+Allocate a mutable buffer for tree turn statistic `ρ`.
+"""
+function empty_ρ end
+
+"""
+$(FUNCTIONNAME)(trajectory)
+
+Allocate a mutable buffer for phasepoint turn statistic `p♯`.
+"""
+function empty_p♯ end
+
+"""
+$(FUNCTIONNAME)(trajectory, ρ, p♯₋, p♯₊)
+
+Test if the relevant section of the tree is *turning* as defined by the turn statistics.
+"""
+function is_turning end
+
+####
+#### Pre-allocated buffers
+####
+
+"""
+$(TYPEDEF)
+
+# Fields
+
+$(FIELDS)
+"""
+struct Buffers{Z,R,P}
+    z₋::Z
+    z₊::Z
+    ẑ::Z
+    ẑs::Vector{Z}
+    p♯₋::P
+    p♯₊::P
+    p♯s::Vector{P}
+    ρ::R
+    ρs::Vector{R}
+end
+
+function Buffers(trajectory, max_depth::Integer)
+    @argcheck 0 < max_depth ≤ SUPPORTED_MAX_DEPTH
+    _vec(f) = [f(trajectory) for _ in 1:(max_depth + 1)]
+    Buffers(empty_z(trajectory), empty_z(trajectory), empty_z(trajectory), _vec(empty_z),
+            empty_p♯(trajectory), empty_p♯(trajectory), _vec(empty_p♯),
+            empty_ρ(trajectory), _vec(empty_ρ))
+end
+
+"""
+$(SIGNATURES)
+
+Initialize `buffers` from the point `z`, for sampling a trajectory.
+"""
+function initialize_buffers!(buffers, trajectory, z)
+    @unpack z₋, z₊, ẑ, p♯₋, p♯₊, ρ = buffers
+    copy!(z₋, z)
+    copy!(z₊, z)
+    copy!(ẑ, z)
+    get_p♯!(p♯₋, trajectory, z)
+    copy!(p♯₊, p♯₋)
+    get_ρ!(ρ, trajectory, z)
+    nothing
+end
+
+mutable struct Visited{T <: AbstractFloat}
+    "Number of visited nodes (other than the initial one)"
+    leapfrog_steps::Int
+    "Log of sum ``min(1, exp(Δ))`` for all visited nodes (other than the initial one)."
+    log∑a::T
+end
+
+Visited(::Type{T}) where {T <: AbstractFloat} = Visited(0, zero(T))
+
+Visited() = Visited(Float64)
+
+"""
+$(SIGNATURES)
+
+Initialize the visited leaf statistics `visited`, for sampling a trajectory.
+"""
+function initialize_visited!(visited::Visited)
+    visited.leapfrog_steps = 0
+    visited.log∑a = 0
+    nothing
+end
+
+"""
+$(SIGNATURES)
+
+Add `Δ` from a visited node.
+"""
+function add_Δ!(visited::Visited, Δ)
+    visited.leapfrog_steps += 1
+    visited.log∑a = logaddexp(visited.log∑a, min(0, Δ))
+    nothing
+end
+
+"""
+$(SIGNATURES)
+
+Build a tree of the given `depth` on `trajectory`, adjacent to `z₋` or `z₊` in buffers, in
+the direction specified by `is_forward`.
+
+`π₀` is the log probability at the initial point and is used to calculate the difference `Δ`
+for each phasepoint.
+
+# Return values
+
+1. When `Δ < min_Δ`, anywhere in the tree, a phasepoint is considered *divergent* and `-Inf`
+is returned.
+
+2. When a turning subtree is encountered, `NaN` is returned.
+
+3. Otherwise, the returned value is the *weight* ``log(∑ exp(Δ))`` for the whole tree that
+was built.
+
+# Buffers and invariants
+
+Acceptance information on all visited notes is accumulated in `visited`, regardless of
+divergence and turning.
+
+Buffers `buffer_index:(buffer_index + depth)` may be overwritten, and assumed to be
+available for this purpose.
+
+When the return value is *finite*,
+
+1. `buffers.ẑs[buffer_index]` contains the proposal,
+
+2. `buffers.ρs[buffer_index]` contains the sum of the `ρ`s from all nodes,
+
+3. `buffers.p♯s[buffer_index]` contain the `p♯` for the endpoint of the tree (farthest from
+the initial edge).
+"""
+function build_adjacent!(rng, trajectory, min_Δ, π₀, depth::Int, is_forward::Bool,
+                         visited::Visited, buffers::Buffers, buffer_index::Int)
+    @unpack z₋, z₊, ẑs, p♯s, ρs = buffers
+    if depth == 0
+        z = is_forward ? z₊ : z₋
+        move!(z, trajectory, is_forward)
+        Δ = log_probability(trajectory, z) - π₀
+        # always update acceptance statistics (even for divergent)
+        add_Δ!(visited, Δ)
+        # when divergent, return -∞
+        Δ < min_Δ && return oftype(Δ, -Inf)
+        # propose this leaf for the trivial subtree
+        copy!(ẑs[buffer_index], z)
+        # obtain turn statistics for leaf
+        get_p♯!(p♯s[buffer_index], trajectory, z)
+        get_ρ!(ρs[buffer_index], trajectory, z)
+        # return Δ
+        Δ
+    else
+        w₁ = build_adjacent!(rng, trajectory, min_Δ, π₀, depth - 1, is_forward,
+                             visited, buffers, buffer_index)
+        isfinite(w₁) || return w₁
+        w₂ = build_adjacent!(rng, trajectory, min_Δ, π₀, depth - 1, is_forward,
+                             visited, buffers, buffer_index + 1)
+        isfinite(w₂) || return w₂
+        w = logaddexp(w₁, w₂)
+        accept_Δ(rng, w₂ - w) && copy!(ẑs[buffer_index], ẑs[buffer_index + 1])
+        add_ρ!(ρs[buffer_index], trajectory, ρs[buffer_index + 1])
+        if is_turning(trajectory, ρs[buffer_index],
+                      p♯s[buffer_index], p♯s[buffer_index + 1])
+            oftype(w, NaN)
+        else
+            copy!(p♯s[buffer_index], p♯s[buffer_index + 1])
+            w
+        end
+    end
+end
+
+function transition!(rng, trajectory, min_Δ, visited, max_depth, z, direction_flags, buffers)
+    depth = 0
+    initialize_visited!(visited, z)
+    w = 0.0
+    π₀ = log_probability(trajectory, z)
+    while depth < max_depth
+        is_forward = Bool(direction_flags & true)
+        w′ = build_adjacent!(rng, trajectory, min_Δ, visited, depth, is_forward, buffers, 1)
+        isfinite(w′) || break   # adjacent tree is divergent or turning
+        accept_Δ(rng, w′ - w) && copy!(ẑ, ẑs[1])
+        add_ρ!(trajectory, ρ, ρs[1])
+        is_turning(trajectory, ρ, p♯₋, p♯₊) && break
+        direction_flags >>= 1
+    end
+    depth
+end
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,38 +1,38 @@
-using DynamicHMC
+using DynamicHMC, Test
 
-using DynamicHMC:
-    # Hamiltonian
-    GaussianKE, Hamiltonian, PhasePoint, neg_energy, phasepoint_in,
-    rand_phasepoint, leapfrog, move,
-    # building blocks
-    rand_bool, TurnStatistic, combine_turnstats, Proposal,
-    combined_logprob_logweight, combine_proposals,
-    DivergenceStatistic, combine_divstats, divergence_statistic, isdivergent,
-    get_acceptance_rate, isturning, adjacent_tree, sample_trajectory,
-    # stepsize
-    InitialStepsizeSearch, find_initial_stepsize,
-    # transitions and tuning
-    NUTS_transition, NUTS_init, StepsizeTuner, StepsizeCovTuner, tune,
-    TunerSequence, bracketed_doubling_tuner
+# using DynamicHMC:
+#     # Hamiltonian
+#     GaussianKE, Hamiltonian, PhasePoint, neg_energy, phasepoint_in,
+#     rand_phasepoint, leapfrog, move,
+#     # building blocks
+#     rand_bool, TurnStatistic, combine_turnstats, Proposal,
+#     combined_logprob_logweight, combine_proposals,
+#     DivergenceStatistic, combine_divstats, divergence_statistic, isdivergent,
+#     get_acceptance_rate, isturning, adjacent_tree, sample_trajectory,
+#     # stepsize
+#     InitialStepsizeSearch, find_initial_stepsize,
+#     # transitions and tuning
+#     NUTS_transition, NUTS_init, StepsizeTuner, StepsizeCovTuner, tune,
+#     TunerSequence, bracketed_doubling_tuner
 
-using Test
+# using Test
 
-using ArgCheck: @argcheck
-using DataStructures
-using Distributions
-using DocStringExtensions: SIGNATURES
-import ForwardDiff
-using LinearAlgebra
-using LogDensityProblems:
-    logdensity, dimension, ValueGradient, AbstractLogDensityProblem, LogDensityProblems
-using MCMCDiagnostics: effective_sample_size, potential_scale_reduction
-using Parameters
-import Random
-using Random: randn, rand
-using StatsBase: mean_and_cov, mean_and_std
-using StatsFuns: logaddexp
-using Statistics: mean, quantile, Statistics
-using Suppressor
+# using ArgCheck: @argcheck
+# using DataStructures
+# using Distributions
+# using DocStringExtensions: SIGNATURES
+# import ForwardDiff
+# using LinearAlgebra
+# using LogDensityProblems:
+#     logdensity, dimension, ValueGradient, AbstractLogDensityProblem, LogDensityProblems
+# using MCMCDiagnostics: effective_sample_size, potential_scale_reduction
+# using Parameters
+# import Random
+# using Random: randn, rand
+# using StatsBase: mean_and_cov, mean_and_std
+# using StatsFuns: logaddexp
+# using Statistics: mean, quantile, Statistics
+# using Suppressor
 
 include("utilities.jl")
 
@@ -45,12 +45,16 @@ macro include_testset(filename)
     end
 end
 
-@include_testset("test-Hamiltonian-leapfrog.jl")
-@include_testset("test-buildingblocks.jl")
-@include_testset("test-stepsize.jl")
-@include_testset("test-sample-dummy.jl")
-@include_testset("test-tuners.jl")
-@include_testset("test-sample-normal.jl")
-@include_testset("test-normal-mcmc.jl")
-@include_testset("test-statistics.jl")
-@include_testset("test-reporting.jl")
+# @include_testset("test-Hamiltonian-leapfrog.jl")
+# @include_testset("test-buildingblocks.jl")
+# @include_testset("test-stepsize.jl")
+# @include_testset("test-sample-dummy.jl")
+# @include_testset("test-tuners.jl")
+# @include_testset("test-sample-normal.jl")
+# @include_testset("test-normal-mcmc.jl")
+# @include_testset("test-statistics.jl")
+# @include_testset("test-reporting.jl")
+
+# NEW CODE
+
+@include_testset("test_trajectories.jl")

--- a/test/test_trajectories.jl
+++ b/test/test_trajectories.jl
@@ -1,0 +1,100 @@
+#####
+##### Tests for the trajectories module
+#####
+
+using Test, DynamicHMC.Trajectories, StatsFuns, ArgCheck
+
+Base.@kwdef struct DummyTrajectory
+    visited::Vector = Any[]
+    turning_left = Inf
+    turning_right = -Inf
+end
+
+####
+#### mock trajectory type
+####
+
+function Trajectories.move!(z, trajectory::DummyTrajectory, is_forward::Bool)
+    z[] += is_forward ? 1 : -1
+    push!(trajectory.visited, z[])
+    nothing
+end
+
+_arr0(v = missing) = (a = Array{Union{Missing,Int}}(undef, ()); a[] = v; a)
+
+Trajectories.log_probability(::DummyTrajectory, z) = z[]
+Trajectories.get_p♯!(p♯, ::DummyTrajectory, z) = (p♯[] = z[]; nothing)
+Trajectories.get_ρ!(ρ, ::DummyTrajectory, z) = (ρ[] = z[]; nothing)
+Trajectories.add_ρ!(ρ, ::DummyTrajectory, ρ′) = (ρ .+= ρ′; nothing)
+Trajectories.empty_z(::DummyTrajectory) = _arr0()
+Trajectories.empty_ρ(::DummyTrajectory) = _arr0()
+Trajectories.empty_p♯(::DummyTrajectory) = _arr0()
+function Trajectories.is_turning(t::DummyTrajectory, _, p♯₋, p♯₊)
+    @argcheck p♯₋[] ≤ p♯₊[] "order mixup"
+    t.turning_left ≤ p♯₋[] && p♯₊[] ≤ t.turning_right
+end
+
+t = DummyTrajectory()
+max_depth = 5
+b = Buffers(t, max_depth)
+v = Visited()
+
+@testset "fresh buffer consistency" begin
+    @test length(b.ẑs) == length(b.ρs) == length(b.p♯s) == max_depth + 1
+    initialize_buffers!(b, t, _arr0(0))
+    @test b.z₋ == b.z₊ == b.ẑ == _arr0(0)
+    @test b.p♯₋ == b.p♯₊ == _arr0(0)
+    @test b.ρ == _arr0(0)
+    initialize_visited!(v)
+    @test v.leapfrog_steps == 0
+end
+
+@testset "building adjacent 0" begin
+    empty!(t.visited)
+    initialize_visited!(v)
+    initialize_buffers!(b, t, _arr0(0))
+    # rng = nothing, test that it is never called
+    @test build_adjacent!(nothing, t, -1000, 0.0, 0, true, v, b, 1) == 1.0
+    @test t.visited == [1]
+    @test v.leapfrog_steps == 1
+    @test v.log∑a ≈ log(2)      # log(exp(0) + exp(0))
+    @test b.z₋ == _arr0(0)
+    @test b.z₊ == _arr0(1)
+    @test b.ẑs[1] == _arr0(1)
+    @test b.ρs[1] == _arr0(1)
+    @test b.p♯s[1] == _arr0(1)
+end
+
+@testset "building adjacent 1" begin
+    empty!(t.visited)
+    initialize_visited!(v)
+    initialize_buffers!(b, t, _arr0(0))
+    r = DummyRNG(zeros(10))     # always accept
+    @test build_adjacent!(r, t, -1000, 0.0, 1, true, v, b, 1) ≈ log(exp(1.0) + exp(2.0))
+    @test r.index == 1
+    @test t.visited == 1:2
+    @test v.leapfrog_steps == 2
+    @test v.log∑a ≈ log(3 * exp(0))
+    @test b.z₋ == _arr0(0)
+    @test b.z₊ == _arr0(2)
+    @test b.ẑs[1] == _arr0(2)
+    @test b.ρs[1] == _arr0(1 + 2)
+    @test b.p♯s[1] == _arr0(2)
+end
+
+@testset "building adjacent 2" begin
+    empty!(t.visited)
+    initialize_visited!(v)
+    initialize_buffers!(b, t, _arr0(0))
+    r = DummyRNG(zeros(10))
+    @test build_adjacent!(r, t, -1000, 0.0, 2, true, v, b, 1) ≈ logsumexp(1:4)
+    @test r.index == 3
+    @test t.visited == 1:4
+    @test v.leapfrog_steps == 4
+    @test v.log∑a ≈ log(5 * exp(0))
+    @test b.z₋ == _arr0(0)
+    @test b.z₊ == _arr0(4)
+    @test b.ẑs[1] == _arr0(4)
+    @test b.ρs[1] == _arr0(sum(1:4))
+    @test b.p♯s[1] == _arr0(4)
+end

--- a/test/test_trajectories.jl
+++ b/test/test_trajectories.jl
@@ -20,15 +20,18 @@ function Trajectories.move!(z, trajectory::DummyTrajectory, is_forward::Bool)
     nothing
 end
 
-_arr0(v = missing) = (a = Array{Union{Missing,Int}}(undef, ()); a[] = v; a)
+_arr0(T, v = missing) = (a = Array{Union{Missing,T}}(undef, ()); a[] = v; a)
+_z(𝑧) = _arr0(Int64, 𝑧)
+_p♯(𝑧) = _arr0(Float64, 𝑧)
+_ρ(𝑧) = _arr0(Float64, 𝑧 * √2)
 
-Trajectories.log_probability(::DummyTrajectory, z) = z[]
-Trajectories.get_p♯!(p♯, ::DummyTrajectory, z) = (p♯[] = z[]; nothing)
-Trajectories.get_ρ!(ρ, ::DummyTrajectory, z) = (ρ[] = z[]; nothing)
+Trajectories.log_probability(::DummyTrajectory, z) = z[] * 0.1
+Trajectories.get_p♯!(p♯, ::DummyTrajectory, z) = (p♯ .= _p♯(z[]); nothing)
+Trajectories.get_ρ!(ρ, ::DummyTrajectory, z) = (ρ .= _ρ(z[]); nothing)
 Trajectories.add_ρ!(ρ, ::DummyTrajectory, ρ′) = (ρ .+= ρ′; nothing)
-Trajectories.empty_z(::DummyTrajectory) = _arr0()
-Trajectories.empty_ρ(::DummyTrajectory) = _arr0()
-Trajectories.empty_p♯(::DummyTrajectory) = _arr0()
+Trajectories.empty_z(::DummyTrajectory) = _arr0(Int)
+Trajectories.empty_ρ(::DummyTrajectory) = _arr0(Float64)
+Trajectories.empty_p♯(::DummyTrajectory) = _arr0(Float64)
 function Trajectories.is_turning(t::DummyTrajectory, _, p♯₋, p♯₊)
     @argcheck p♯₋[] ≤ p♯₊[] "order mixup"
     t.turning_left ≤ p♯₋[] && p♯₊[] ≤ t.turning_right
@@ -41,10 +44,10 @@ v = Visited()
 
 @testset "fresh buffer consistency" begin
     @test length(b.ẑs) == length(b.ρs) == length(b.p♯s) == max_depth + 1
-    initialize_buffers!(b, t, _arr0(0))
-    @test b.z₋ == b.z₊ == b.ẑ == _arr0(0)
-    @test b.p♯₋ == b.p♯₊ == _arr0(0)
-    @test b.ρ == _arr0(0)
+    initialize_buffers!(b, t, _z(0))
+    @test b.z₋ == b.z₊ == b.ẑ == _z(0)
+    @test b.p♯₋ == b.p♯₊ == _p♯(0)
+    @test b.ρ == _ρ(0)
     initialize_visited!(v)
     @test v.leapfrog_steps == 0
 end
@@ -52,49 +55,49 @@ end
 @testset "building adjacent 0" begin
     empty!(t.visited)
     initialize_visited!(v)
-    initialize_buffers!(b, t, _arr0(0))
+    initialize_buffers!(b, t, _z(0))
     # rng = nothing, test that it is never called
-    @test build_adjacent!(nothing, t, -1000, 0.0, 0, true, v, b, 1) == 1.0
+    @test build_adjacent!(nothing, t, -1000, 0.0, 0, true, v, b, 1) == 0.1
     @test t.visited == [1]
     @test v.leapfrog_steps == 1
     @test v.log∑a ≈ log(2)      # log(exp(0) + exp(0))
-    @test b.z₋ == _arr0(0)
-    @test b.z₊ == _arr0(1)
-    @test b.ẑs[1] == _arr0(1)
-    @test b.ρs[1] == _arr0(1)
-    @test b.p♯s[1] == _arr0(1)
+    @test b.z₋ == _z(0)
+    @test b.z₊ == _z(1)
+    @test b.ẑs[1] == _z(1)
+    @test b.ρs[1] == _ρ(1)
+    @test b.p♯s[1] == _p♯(1)
 end
 
 @testset "building adjacent 1" begin
     empty!(t.visited)
     initialize_visited!(v)
-    initialize_buffers!(b, t, _arr0(0))
+    initialize_buffers!(b, t, _z(0))
     r = DummyRNG(zeros(10))     # always accept
-    @test build_adjacent!(r, t, -1000, 0.0, 1, true, v, b, 1) ≈ log(exp(1.0) + exp(2.0))
+    @test build_adjacent!(r, t, -1000, 0.0, 1, true, v, b, 1) ≈ log(exp(0.1) + exp(0.2))
     @test r.index == 1
     @test t.visited == 1:2
     @test v.leapfrog_steps == 2
     @test v.log∑a ≈ log(3 * exp(0))
-    @test b.z₋ == _arr0(0)
-    @test b.z₊ == _arr0(2)
-    @test b.ẑs[1] == _arr0(2)
-    @test b.ρs[1] == _arr0(1 + 2)
-    @test b.p♯s[1] == _arr0(2)
+    @test b.z₋ == _z(0)
+    @test b.z₊ == _z(2)
+    @test b.ẑs[1] == _z(2)
+    @test b.ρs[1] ≈ _ρ(sum(1:2))
+    @test b.p♯s[1] == _p♯(2)
 end
 
 @testset "building adjacent 2" begin
     empty!(t.visited)
     initialize_visited!(v)
-    initialize_buffers!(b, t, _arr0(0))
+    initialize_buffers!(b, t, _z(0))
     r = DummyRNG(zeros(10))
-    @test build_adjacent!(r, t, -1000, 0.0, 2, true, v, b, 1) ≈ logsumexp(1:4)
+    @test build_adjacent!(r, t, -1000, 0.0, 2, true, v, b, 1) ≈ logsumexp((1:4) .* 0.1)
     @test r.index == 3
     @test t.visited == 1:4
     @test v.leapfrog_steps == 4
     @test v.log∑a ≈ log(5 * exp(0))
-    @test b.z₋ == _arr0(0)
-    @test b.z₊ == _arr0(4)
-    @test b.ẑs[1] == _arr0(4)
-    @test b.ρs[1] == _arr0(sum(1:4))
-    @test b.p♯s[1] == _arr0(4)
+    @test b.z₋ == _z(0)
+    @test b.z₊ == _z(4)
+    @test b.ẑs[1] == _z(4)
+    @test b.ρs[1] ≈ _ρ(sum(1:4))
+    @test b.p♯s[1] == _p♯(4)
 end

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -2,81 +2,104 @@
 #### general test environment
 ####
 
+using Random, DocStringExtensions
+
 const RNG = Random.GLOBAL_RNG   # shorthand
 Random.seed!(RNG, UInt32[0x23ef614d, 0x8332e05c, 0x3c574111, 0x121aa2f4])
 
 "Tolerant testing in a CI environment."
 const RELAX = (k = "CONTINUOUS_INTEGRATION"; haskey(ENV, k) && ENV[k] == "true")
 
-"""
-    $SIGNATURES
+# """
+#     $SIGNATURES
 
-Random positive definite matrix of size `n` x `n` (for testing).
-"""
-function rand_Σ(::Type{Symmetric}, n)
-    A = randn(n, n)
-    Symmetric(A'*A .+ 0.01)
-end
+# Random positive definite matrix of size `n` x `n` (for testing).
+# """
+# function rand_Σ(::Type{Symmetric}, n)
+#     A = randn(n, n)
+#     Symmetric(A'*A .+ 0.01)
+# end
 
-rand_Σ(::Type{Diagonal}, n) = Diagonal(randn(n).^2 .+ 0.01)
+# rand_Σ(::Type{Diagonal}, n) = Diagonal(randn(n).^2 .+ 0.01)
 
-rand_Σ(n::Int) = rand_Σ(Symmetric, n)
+# rand_Σ(n::Int) = rand_Σ(Symmetric, n)
+
+# ####
+# #### use multivariate distributions as tests
+# ####
+
+# """
+# Obtain the log density from a distribution.
+# """
+# struct DistributionLogDensity{D <: Distribution{Multivariate,Continuous}
+#                               } <: AbstractLogDensityProblem
+#     distribution::D
+# end
+
+# LogDensityProblems.dimension(ℓ::DistributionLogDensity) = length(ℓ.distribution)
+
+# function LogDensityProblems.logdensity(::Type{ValueGradient}, ℓ::DistributionLogDensity,
+#                                        x::AbstractVector)
+#     ValueGradient(logpdf(ℓ.distribution, x), gradlogpdf(ℓ.distribution, x))
+# end
+
+# DistributionLogDensity(::Type{MvNormal}, n::Int) = # canonical
+#     DistributionLogDensity(MvNormal(zeros(n), ones(n)))
+
+# Statistics.mean(ℓ::DistributionLogDensity) = mean(ℓ.distribution)
+# Statistics.var(ℓ::DistributionLogDensity) = var(ℓ.distribution)
+# Statistics.cov(ℓ::DistributionLogDensity) = cov(ℓ.distribution)
+# Base.rand(ℓ::DistributionLogDensity) = rand(ℓ.distribution)
+
+# """
+# A function returning a log density (as a `ValueGradient`).
+# """
+# struct FunctionLogDensity{F} <: AbstractLogDensityProblem
+#     dimension::Int
+#     f::F
+# end
+
+# LogDensityProblems.dimension(ℓ::FunctionLogDensity) = length(ℓ.distribution)
+
+# function LogDensityProblems.logdensity(::Type{ValueGradient}, ℓ::FunctionLogDensity,
+#                                        x::AbstractVector)
+#     ℓ.f(x)::ValueGradient
+# end
+
+# """
+# $(SIGNATURES)
+
+# A log density always returning a constant (for testing).
+# """
+# FunctionLogDensity(v::ValueGradient) = FunctionLogDensity(length(v.gradient), _ -> v)
+
+# "Random Hamiltonian `H` with phasepoint `z`, with dimension `K`."
+# function rand_Hz(K)
+#     μ = randn(K)
+#     Σ = rand_Σ(K)
+#     κ = GaussianKE(inv(rand_Σ(Diagonal, K)))
+#     H = Hamiltonian(DistributionLogDensity(MvNormal(μ, Matrix(Σ))), κ)
+#     z = rand_phasepoint(RNG, H, μ)
+#     H, z
+# end
 
 ####
-#### use multivariate distributions as tests
+#### Dummy random number generator for testing
 ####
 
 """
-Obtain the log density from a distribution.
+$(TYPEDEF)
+
+A dummy random number generator that just delivers the give `Float64` values. It only
+supports the `rand` method without arguments
 """
-struct DistributionLogDensity{D <: Distribution{Multivariate,Continuous}
-                              } <: AbstractLogDensityProblem
-    distribution::D
+mutable struct DummyRNG <: Random.AbstractRNG
+    "Number of values used up."
+    index::Int
+    "Vector of values."
+    values::Vector{Float64}
 end
 
-LogDensityProblems.dimension(ℓ::DistributionLogDensity) = length(ℓ.distribution)
+DummyRNG(values::AbstractVector) = DummyRNG(0, values)
 
-function LogDensityProblems.logdensity(::Type{ValueGradient}, ℓ::DistributionLogDensity,
-                                       x::AbstractVector)
-    ValueGradient(logpdf(ℓ.distribution, x), gradlogpdf(ℓ.distribution, x))
-end
-
-DistributionLogDensity(::Type{MvNormal}, n::Int) = # canonical
-    DistributionLogDensity(MvNormal(zeros(n), ones(n)))
-
-Statistics.mean(ℓ::DistributionLogDensity) = mean(ℓ.distribution)
-Statistics.var(ℓ::DistributionLogDensity) = var(ℓ.distribution)
-Statistics.cov(ℓ::DistributionLogDensity) = cov(ℓ.distribution)
-Base.rand(ℓ::DistributionLogDensity) = rand(ℓ.distribution)
-
-"""
-A function returning a log density (as a `ValueGradient`).
-"""
-struct FunctionLogDensity{F} <: AbstractLogDensityProblem
-    dimension::Int
-    f::F
-end
-
-LogDensityProblems.dimension(ℓ::FunctionLogDensity) = length(ℓ.distribution)
-
-function LogDensityProblems.logdensity(::Type{ValueGradient}, ℓ::FunctionLogDensity,
-                                       x::AbstractVector)
-    ℓ.f(x)::ValueGradient
-end
-
-"""
-$(SIGNATURES)
-
-A log density always returning a constant (for testing).
-"""
-FunctionLogDensity(v::ValueGradient) = FunctionLogDensity(length(v.gradient), _ -> v)
-
-"Random Hamiltonian `H` with phasepoint `z`, with dimension `K`."
-function rand_Hz(K)
-    μ = randn(K)
-    Σ = rand_Σ(K)
-    κ = GaussianKE(inv(rand_Σ(Diagonal, K)))
-    H = Hamiltonian(DistributionLogDensity(MvNormal(μ, Matrix(Σ))), κ)
-    z = rand_phasepoint(RNG, H, μ)
-    H, z
-end
+Base.rand(rng::DummyRNG) = rng.values[rng.index += 1]


### PR DESCRIPTION
Rewrite the trajectory sampler to use pre-allocated buffers.

TODO:

- [x] buffers and adjacent tree building code
- [x] rudimentary consistency tests for adjacent tree building
- [ ] deterministic tests for transitions
- [ ] stochastic tests for transitions (conditional on direction flags)
- [ ] deterministic tests for turning
- [ ] stochastic tests for turning
- [ ] stochastic tests for acceptance ratio based on visited points