### PR TITLE
Customize first stages of warmup.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ os:
   - linux
   # - osx
 julia:
-  - 1.0
   - 1.1
   - 1.2
   - nightly

--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ StatsFuns = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
 
 [compat]
 LogDensityProblems = "^0.9.0"
-julia = "1"
+julia = "1.1"
 
 [extras]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"


### PR DESCRIPTION
Fixes #81.

1. add a no-op warmup (`nothing`), document this possibility in
`default_warmup_stages`

2. make `FindLocalOptimum` have a penalty term, to avoid going down
funnels

3. limit iterations for `FindLocalOptimum`, not aiming for the actual
local maximum (as it does not matter much), consequently remove the
non-convergence warning.

4. make local optimization and stepsize search customizable in
`default_warmup_stages` and `fixed_stepsize_warmup_stages`.

5. add an example about having no optimization