### PR TITLE
Iterator interface

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,6 +12,7 @@ NLSolversBase = "d41bc354-129a-5804-8e4c-c37616107c6c"
 Optim = "429524aa-4258-5aef-a3af-852621145aeb"
 Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+ResumableFunctions = "c5292f4c-5179-55e1-98c5-05642aab7184"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsFuns = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
 

--- a/src/mcmc.jl
+++ b/src/mcmc.jl
@@ -276,7 +276,7 @@ using ResumableFunctions
 
 # Markov Chain Monte Carlo for `sampling_logdensity`, with the adapted `warmup_state`.
 
-# Return a `NamedTuple` of
+# Return a `NamedTup`le` of
 
 # - `chain`, a vector of length `N` that contains the positions,
 
@@ -448,8 +448,8 @@ function mcmc_keep_warmup(rng::AbstractRNG, ℓ, N::Integer;
     initial_warmup_state = initialize_warmup_state(rng, ℓ; initialization...)
     warmup, warmup_state = _warmup(sampling_logdensity, warmup_stages, initial_warmup_state)
     inference = mcmc(sampling_logdensity, N, warmup_state)
-    (initial_warmup_state = initial_warmup_state, warmup = warmup,
-     final_warmup_state = warmup_state, inference = inference)
+    # (initial_warmup_state = initial_warmup_state, warmup = warmup,
+    #  final_warmup_state = warmup_state, inference = inference)
 end
 
 """
@@ -496,10 +496,10 @@ mcmc_with_warmup(rng, ℓ, N;
 function mcmc_with_warmup(rng, ℓ, N; initialization = (),
                           warmup_stages = default_warmup_stages(),
                           algorithm = NUTS(), reporter = default_reporter())
-    @unpack final_warmup_state, inference =
+    # @unpack final_warmup_state, inference =
         mcmc_keep_warmup(rng, ℓ, N; initialization = initialization,
                          warmup_stages = warmup_stages, algorithm = algorithm,
                          reporter = reporter)
-    @unpack κ, ϵ = final_warmup_state
-    (inference..., κ = κ, ϵ = ϵ)
+    # @unpack κ, ϵ = final_warmup_state
+    # (inference..., κ = κ, ϵ = ϵ)
 end

--- a/src/mcmc.jl
+++ b/src/mcmc.jl
@@ -283,8 +283,15 @@ using ResumableFunctions
 # - `tree_statistics`, a vector of length `N` with the tree statistics.
 # """
 @resumable function mcmc(sampling_logdensity, N, warmup_state)
-    @unpack rng, ℓ, algorithm, reporter = sampling_logdensity
-    @unpack Q, κ, ϵ = warmup_state
+    rng = sampling_logdensity.rng
+    ℓ = sampling_logdensity.ℓ
+    algorithm = sampling_logdensity.algorithm
+    reporter = sampling_logdensity.reporter
+
+    Q = warmup_state.Q
+    κ = warmup_state.κ
+    ϵ = warmup_state.ϵ
+
 
     H = Hamiltonian(κ, ℓ)
     while true


### PR DESCRIPTION
This refactors `mcmc` to return a `ResumableFunction`. There's some small overhead, but it's convenient for prototyping and overhead in minimal relative to function and gradient evaluation.

This required some other changes as well:

- `@unpack` from `Parameters.jl` was causing problems inside the `@resumable`, so I expanded it manually
- There were originally some steps taken after the samples are done. But in an iterator approach there is no "done" - samples go on as long as they need to. Maybe kappa and epsilon can be appended to the `meta` field at each step of the iterator. Overhead for this seems very minor.
- I'm not using the reporting interface. I think this can be pulled outside as post-processing on the iterator, with no need to be referenced at all from within `mcmc`

Maybe the best way to wrap this is to have the original behavior if `N` is provided, and to use the iterator interface if not. This would avoid breaking existing code.