### PR TITLE
dustoff: fix tests, version bumps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ julia:
   - 1.1
   - 1.2
   - 1.3
+  - 1.4
+  - 1.5
   - nightly
 notifications:
   email: false
@@ -23,7 +25,7 @@ git:
 jobs:
   include:
     - stage: Documentation
-      julia: 1.4
+      julia: 1.5
       os: linux
       script:
         - julia --project=docs -e 'using Pkg; Pkg.instantiate(); Pkg.develop(PackageSpec(path=pwd()))'

--- a/src/DynamicHMC.jl
+++ b/src/DynamicHMC.jl
@@ -24,8 +24,7 @@ export
 
 using ArgCheck: @argcheck
 using DocStringExtensions: FIELDS, FUNCTIONNAME, SIGNATURES, TYPEDEF
-using LinearAlgebra
-using LinearAlgebra: checksquare, Diagonal, Symmetric
+using LinearAlgebra: checksquare, cholesky, diag, dot, Diagonal, Symmetric, UniformScaling
 using LogDensityProblems: capabilities, LogDensityOrder, dimension, logdensity_and_gradient
 import NLSolversBase, Optim # optimization step in mcmc
 using Parameters: @with_kw, @unpack

--- a/test/coverage/coverage.jl
+++ b/test/coverage/coverage.jl
@@ -1,6 +1,6 @@
 # only push coverage from one bot
 get(ENV, "TRAVIS_OS_NAME", nothing)       == "linux" || exit(0)
-get(ENV, "TRAVIS_JULIA_VERSION", nothing) == "1.1"   || exit(0)
+get(ENV, "TRAVIS_JULIA_VERSION", nothing) == "1.5"   || exit(0)
 
 using Coverage
 

--- a/test/test-hamiltonian.jl
+++ b/test/test-hamiltonian.jl
@@ -153,10 +153,13 @@ end
     end
 
     for _ in 1:100
-        @unpack H, z = rand_Hz(2)
+        @unpack H, z, Σ = rand_Hz(2)
         z1 = z
         N = 3
-        ϵ = 0.1
+
+        # use something near the stable stepsize to avoid numerical issue, but perturb it a
+        # bit for testing
+        ϵ = find_stable_ϵ(H.κ, Σ) * (0.5 + rand(RNG))
 
         # forward
         for _ in 1:N


### PR DESCRIPTION
1. fix tests that fail on 1.5 becaue of the RNG. The cause was a numerically ill-conditioned stepsize/curvature combination, using a
stable one now. 

2. bump versions

3. using symbols for LinearAlgebra explicitly