### PR TITLE
Add a progress bar based on `ProgressMeter.jl`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- add a progress bar ([#136](https://github.com/tpapp/DynamicHMC.jl/pull/136))
+
 # v2.1.4
 
 - compat bumps extension

--- a/Project.toml
+++ b/Project.toml
@@ -11,6 +11,7 @@ LogDensityProblems = "6fdf6af0-433a-55f7-b3ed-c6c6e0b8df7c"
 NLSolversBase = "d41bc354-129a-5804-8e4c-c37616107c6c"
 Optim = "429524aa-4258-5aef-a3af-852621145aeb"
 Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"
+ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
@@ -21,6 +22,7 @@ LogDensityProblems = "^0.9, 0.10"
 NLSolversBase = "^7"
 Optim = "0.18, 0.19, 0.20, 0.21, 0.22"
 Parameters = "^0.11, ^0.12"
+ProgressMeter = "1"
 julia = "^1"
 
 [extras]

--- a/docs/src/interface.md
+++ b/docs/src/interface.md
@@ -38,6 +38,7 @@ Progress reports can be explicit or silent.
 ```@docs
 NoProgressReport
 LogProgressReport
+ProgressMeterReport
 ```
 
 ## Algorithm and parameters

--- a/src/DynamicHMC.jl
+++ b/src/DynamicHMC.jl
@@ -17,7 +17,7 @@ export
     # NUTS
     TreeOptionsNUTS,
     # reporting
-    NoProgressReport, LogProgressReport,
+    NoProgressReport, LogProgressReport, ProgressMeterReport,
     # mcmc
     InitialStepsizeSearch, DualAveraging, FindLocalOptimum,
     TuningNUTS, mcmc_with_warmup, default_warmup_stages, fixed_stepsize_warmup_stages

--- a/src/mcmc.jl
+++ b/src/mcmc.jl
@@ -252,8 +252,9 @@ function warmup(sampling_logdensity, tuning::TuningNUTS{M}, warmup_state) where 
     H = Hamiltonian(κ, ℓ)
     ϵ_state = initial_adaptation_state(stepsize_adaptation, ϵ)
     ϵs = Vector{Float64}(undef, N)
-    mcmc_reporter = make_mcmc_reporter(reporter, N; tuning = M ≡ Nothing ? "stepsize" :
-                                       "stepsize and $(M) metric")
+    mcmc_reporter = make_mcmc_reporter(reporter, N;
+                                       currently_warmup = true,
+                                       tuning = M ≡ Nothing ? "stepsize" : "stepsize and $(M) metric")
     for i in 1:N
         ϵ = current_ϵ(ϵ_state)
         ϵs[i] = ϵ
@@ -352,7 +353,7 @@ function mcmc(sampling_logdensity, N, warmup_state)
     @unpack Q = warmup_state
     chain = Vector{typeof(Q.q)}(undef, N)
     tree_statistics = Vector{TreeStatisticsNUTS}(undef, N)
-    mcmc_reporter = make_mcmc_reporter(reporter, N)
+    mcmc_reporter = make_mcmc_reporter(reporter, N; currently_warmup = false)
     steps = mcmc_steps(sampling_logdensity, warmup_state)
     for i in 1:N
         Q, tree_statistics[i] = mcmc_next_step(steps, Q)

--- a/src/reporting.jl
+++ b/src/reporting.jl
@@ -36,6 +36,10 @@ Return a reporter which can be used for progress reports with a known number of
 `total_steps`. May return the same reporter, or a related object. Will display `meta` as
 key-value pairs.
 
+## Arguments:
+- `reporter::NoProgressReport`: the original reporter
+- `total_steps`: total number of steps
+
 ## Keyword arguments:
 - `currently_warmup::Bool`: `true` if we are currently doing warmup; `false` if we are currently doing MCMC
 - `meta`: key-value pairs that will be displayed by the reporter

--- a/src/reporting.jl
+++ b/src/reporting.jl
@@ -35,6 +35,10 @@ $(SIGNATURES)
 Return a reporter which can be used for progress reports with a known number of
 `total_steps`. May return the same reporter, or a related object. Will display `meta` as
 key-value pairs.
+
+## Keyword arguments:
+- `currently_warmup::Bool`: `true` if we are currently doing warmup; `false` if we are currently doing MCMC
+- `meta`: key-value pairs that will be displayed by the reporter
 """
 make_mcmc_reporter(reporter::NoProgressReport, total_steps; currently_warmup::Bool=false, meta...) = reporter
 

--- a/src/reporting.jl
+++ b/src/reporting.jl
@@ -131,25 +131,22 @@ $(TYPEDEF)
 
 Report progress via a progress bar, using `ProgressMeter.jl`.
 
-# Fields
-
-$(FIELDS)
+Example usage:
+```julia
+julia> ProgressMeterReport()
+```
 """
 struct ProgressMeterReport
-    log_warmup::Bool
 end
 
-ProgressMeterReport(; log_warmup::Bool = true) = ProgressMeterReport(log_warmup)
-
 struct ProgressMeterReportMCMC{T}
-    log_warmup::Bool
     currently_warmup::Bool
     progress_meter::T
 end
 
 function make_mcmc_reporter(reporter::ProgressMeterReport, total_steps::Integer; currently_warmup::Bool=false, meta...)
     description = currently_warmup ? "Warmup: " : "MCMC: "
-    return ProgressMeterReportMCMC(reporter.log_warmup, currently_warmup, ProgressMeter.Progress(total_steps, 1, description))
+    return ProgressMeterReportMCMC(currently_warmup, ProgressMeter.Progress(total_steps, 1, description))
 end
 
 function report(reporter::ProgressMeterReport, message::AbstractString; meta...)
@@ -165,9 +162,7 @@ function report(reporter::ProgressMeterReport, step::Integer; meta...)
 end
 
 function report(reporter::ProgressMeterReportMCMC, step::Integer; meta...)
-    if ( reporter.log_warmup ) || ( !(reporter.currently_warmup) )
-        ProgressMeter.next!(reporter.progress_meter)
-    end
+    ProgressMeter.next!(reporter.progress_meter)
     return nothing
 end
 

--- a/src/reporting.jl
+++ b/src/reporting.jl
@@ -40,7 +40,7 @@ key-value pairs.
 - `currently_warmup::Bool`: `true` if we are currently doing warmup; `false` if we are currently doing MCMC
 - `meta`: key-value pairs that will be displayed by the reporter
 """
-make_mcmc_reporter(reporter::NoProgressReport, total_steps; currently_warmup::Bool=false, meta...) = reporter
+make_mcmc_reporter(reporter::NoProgressReport, total_steps; currently_warmup::Bool = false, meta...) = reporter
 
 """
 $(TYPEDEF)
@@ -104,7 +104,7 @@ function report(reporter::LogMCMCReport, message::AbstractString; meta...)
     nothing
 end
 
-function make_mcmc_reporter(reporter::LogProgressReport, total_steps::Integer; currently_warmup::Bool=false, meta...)
+function make_mcmc_reporter(reporter::LogProgressReport, total_steps::Integer; currently_warmup::Bool = false, meta...)
     @info "Starting MCMC" total_steps = total_steps meta...
     LogMCMCReport(reporter, total_steps, -1, time_ns())
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,6 +19,7 @@ end
 @include_testset("test-stepsize.jl")
 @include_testset("test-mcmc.jl")
 @include_testset("test-diagnostics.jl")
+@include_testset("test-logging.jl")
 
 ####
 #### sample correctness tests

--- a/test/test-logging.jl
+++ b/test/test-logging.jl
@@ -5,8 +5,6 @@ Q = evaluate_ℓ(ℓ, [1.0])
 reporters_1 = [
     NoProgressReport(),
     ProgressMeterReport(),
-    ProgressMeterReport(; log_warmup = true),
-    ProgressMeterReport(; log_warmup = false),
 ]
 
 reporters_2 = [

--- a/test/test-logging.jl
+++ b/test/test-logging.jl
@@ -1,0 +1,43 @@
+ℓ = multivariate_normal(ones(1))
+κ = GaussianKineticEnergy(1)
+Q = evaluate_ℓ(ℓ, [1.0])
+
+reporters_1 = [
+    NoProgressReport(),
+    ProgressMeterReport(),
+    ProgressMeterReport(; log_warmup = true),
+    ProgressMeterReport(; log_warmup = false),
+]
+
+reporters_2 = [
+    LogProgressReport(),
+]
+
+for reporter in deepcopy(vcat(reporters_1, reporters_2))
+    results = mcmc_with_warmup(RNG, ℓ, 10_000; reporter = reporter)
+end
+
+for reporter in deepcopy(vcat(reporters_1, reporters_2))
+    DynamicHMC.report(reporter, "")
+
+    mcmc_reporter_1 = DynamicHMC.make_mcmc_reporter(reporter, 1_000; currently_warmup = true)
+    DynamicHMC.report(mcmc_reporter_1, "")
+    DynamicHMC.report(mcmc_reporter_1, 1)
+
+    mcmc_reporter_2 = DynamicHMC.make_mcmc_reporter(reporter, 1_000; currently_warmup = false)
+    DynamicHMC.report(mcmc_reporter_2, "")
+    DynamicHMC.report(mcmc_reporter_2, 1)
+end
+
+for reporter in deepcopy(reporters_1)
+    DynamicHMC.report(reporter, "")
+    DynamicHMC.report(reporter, 1)
+
+    mcmc_reporter_1 = DynamicHMC.make_mcmc_reporter(reporter, 1_000; currently_warmup = true)
+    DynamicHMC.report(mcmc_reporter_1, "")
+    DynamicHMC.report(mcmc_reporter_1, 1)
+
+    mcmc_reporter_2 = DynamicHMC.make_mcmc_reporter(reporter, 1_000; currently_warmup = false)
+    DynamicHMC.report(mcmc_reporter_2, "")
+    DynamicHMC.report(mcmc_reporter_2, 1)
+end


### PR DESCRIPTION
Fixes #135

This pull request adds the `ProgressMeterReport`, which uses the `ProgressMeter.jl` package to display a progress bar.

To use this reporter, simply set the `reporter` keyword argument when calling `mcmc_with_warmup`:
```julia
reporter = ProgressMeterReport()
```

cc: @tpapp 