### PR TITLE
Add compatibility with Optim 1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DynamicHMC"
 uuid = "bbc10e6e-7c05-544b-b16e-64fede858acb"
 authors = ["Tamas K. Papp <tkpapp@gmail.com>"]
-version = "2.1.6"
+version = "2.2.0"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"
@@ -19,7 +19,7 @@ ArgCheck = "1, 2"
 DocStringExtensions = "^0.8"
 LogDensityProblems = "^0.9, 0.10"
 NLSolversBase = "^7"
-Optim = "0.18, 0.19, 0.20, 0.21, 0.22"
+Optim = "0.18, 0.19, 0.20, 0.21, 0.22, 1"
 Parameters = "^0.11, ^0.12"
 julia = "^1"
 


### PR DESCRIPTION
This PR adds compatibility with Optim 1 and bumps the version number according to ColPrac.

There was no PR by CompatHelper since it currently fails (e.g. https://github.com/tpapp/DynamicHMC.jl/actions/runs/243723439). The problem seems to be the version bound on Documenter in docs/Project.toml in combination with the version from the git repository of Documenter docs/Manifest.toml.