### PR TITLE
Remove local optimization.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- get rid of `local_optimization` in warmup [FIXME PR LINK]
+
 # v2.2.0
 
 - add a progress bar ([#136](https://github.com/tpapp/DynamicHMC.jl/pull/136))

--- a/Project.toml
+++ b/Project.toml
@@ -1,15 +1,13 @@
 name = "DynamicHMC"
 uuid = "bbc10e6e-7c05-544b-b16e-64fede858acb"
 authors = ["Tamas K. Papp <tkpapp@gmail.com>"]
-version = "2.2.0"
+version = "3.0.0"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 LogDensityProblems = "6fdf6af0-433a-55f7-b3ed-c6c6e0b8df7c"
-NLSolversBase = "d41bc354-129a-5804-8e4c-c37616107c6c"
-Optim = "429524aa-4258-5aef-a3af-852621145aeb"
 Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"
 ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
@@ -17,11 +15,9 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 ArgCheck = "1, 2"
-DocStringExtensions = "^0.8"
-LogDensityProblems = "^0.9, 0.10"
-NLSolversBase = "^7"
-Optim = "0.18, 0.19, 0.20, 0.21, 0.22, 1"
-Parameters = "^0.11, ^0.12"
+DocStringExtensions = "0.8"
+LogDensityProblems = "0.9, 0.10"
+Parameters = "0.11, 0.12"
 ProgressMeter = "1"
 julia = "^1"
 

--- a/src/DynamicHMC.jl
+++ b/src/DynamicHMC.jl
@@ -26,7 +26,6 @@ using ArgCheck: @argcheck
 using DocStringExtensions: FIELDS, FUNCTIONNAME, SIGNATURES, TYPEDEF
 using LinearAlgebra: checksquare, cholesky, diag, dot, Diagonal, Symmetric, UniformScaling
 using LogDensityProblems: capabilities, LogDensityOrder, dimension, logdensity_and_gradient
-import NLSolversBase, Optim # optimization step in mcmc
 using Parameters: @with_kw, @unpack
 using Random: AbstractRNG, randn, Random, randexp
 using Statistics: cov, mean, median, middle, quantile, var


### PR DESCRIPTION
Fixes #91.

Rationale: Stan and other NUTS don't actually do anything like this. In practice, it turns out to buy very little, at the cost of 

1. a heavy dependency, and
2. failure for models which have an otherwise innocuous singularity at some point in the posterior.

This is technically a breaking change, hence the version increment.