### PR TITLE
compat with LogDensityProblems=0.11

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 [compat]
 ArgCheck = "1, 2"
 DocStringExtensions = "0.8"
-LogDensityProblems = "0.9, 0.10"
+LogDensityProblems = "0.9, 0.10, 0.11"
 Parameters = "0.11, 0.12"
 ProgressMeter = "1"
 julia = "^1"


### PR DESCRIPTION
Otherwise [our downstream code](https://github.com/JuliaGaussianProcesses/AbstractGPs.jl/blob/master/examples/regression-1d/script.jl) keeps getting CompatHelper PRs re LogDensityProblems, but we can't actually check that it works as DynamicHMC keeps back the version.