### PR TITLE
Support Julia LTS and update CompatHelper

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.8' # Replace this with the minimum Julia version that your package supports. E.g. if your package requires Julia 1.5 or higher, change this to '1.5'.
+          - '1.6' # Replace this with the minimum Julia version that your package supports. E.g. if your package requires Julia 1.5 or higher, change this to '1.5'.
           - '1' # Leave this line unchanged. '1' will automatically expand to the latest stable 1.x release of Julia.
           - 'nightly'
         os:

--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -1,22 +1,47 @@
-name: CompatHelper
+# see the docs at https://github.com/JuliaRegistries/CompatHelper.jl
 
+name: CompatHelper
 on:
   schedule:
-    - cron: '00 00 * * *'
+    - cron: 0 0 * * *
   workflow_dispatch:
-
+permissions:
+  contents: write
+  pull-requests: write
 jobs:
   CompatHelper:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        julia-version: [1.2.0]
-        julia-arch: [x86]
-        os: [ubuntu-latest]
+    runs-on: ubuntu-latest
     steps:
-      - name: Pkg.add("CompatHelper")
-        run: julia -e 'using Pkg; Pkg.add("CompatHelper")'
-      - name: CompatHelper.main()
+      - name: Check if Julia is already available in the PATH
+        id: julia_in_path
+        run: which julia
+        continue-on-error: true
+      - name: Install Julia, but only if it is not already available in the PATH
+        uses: julia-actions/setup-julia@v1
+        with:
+          version: '1'
+          arch: ${{ runner.arch }}
+        if: steps.julia_in_path.outcome != 'success'
+      - name: "Add the General registry via Git"
+        run: |
+          import Pkg
+          ENV["JULIA_PKG_SERVER"] = ""
+          Pkg.Registry.add("General")
+        shell: julia --color=yes {0}
+      - name: "Install CompatHelper"
+        run: |
+          import Pkg
+          name = "CompatHelper"
+          uuid = "aa819f21-2bde-4658-8897-bab36330d9b7"
+          version = "3"
+          Pkg.add(; name, uuid, version)
+        shell: julia --color=yes {0}
+      - name: "Run CompatHelper"
+        run: |
+          import CompatHelper
+          CompatHelper.main()
+        shell: julia --color=yes {0}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: julia -e 'using CompatHelper; CompatHelper.main()'
+          COMPATHELPER_PRIV: ${{ secrets.DOCUMENTER_KEY }}
+

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DynamicHMC"
 uuid = "bbc10e6e-7c05-544b-b16e-64fede858acb"
 authors = ["Tamas K. Papp <tkpapp@gmail.com>"]
-version = "3.4.0"
+version = "3.4.1"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"
@@ -25,4 +25,4 @@ LogExpFunctions = "0.3"
 Parameters = "0.11, 0.12"
 ProgressMeter = "1"
 TensorCast = "0.4"
-julia = "1.8"
+julia = "1.6"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -19,4 +19,3 @@ UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 
 [compat]
 LogDensityTestSuite = "0.6"
-

--- a/test/jet.jl
+++ b/test/jet.jl
@@ -1,7 +1,5 @@
-if VERSION >= v"1.7"
-    using JET
-    insert!(LOAD_PATH, 2, "..")
-    @testset "static analysis with JET.jl" begin
-        @test isempty(JET.get_reports(report_package(DynamicHMC, target_modules=(DynamicHMC,))))
-    end
+using JET
+insert!(LOAD_PATH, 2, "..")
+@testset "static analysis with JET.jl" begin
+    @test isempty(JET.get_reports(report_package(DynamicHMC, target_modules=(DynamicHMC,))))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -43,6 +43,7 @@ include("sample-correctness_tests.jl")
 #### statis analysis
 ####
 
-if isempty(VERSION.prerelease)  # do not test on nightly
+# do not test on older Julia versions and nightly
+if VERSION >= v"1.7" && isempty(VERSION.prerelease)
     include("jet.jl")
 end

--- a/test/sample-correctness_tests.jl
+++ b/test/sample-correctness_tests.jl
@@ -70,15 +70,13 @@ end
     NUTS_tests(RNG, ℓ, "mixture of two normals", 1000; τ_alert = 0.15)
 end
 
-if VERSION ≥ v"1.8" # FIXME why is it broken on 1.6? Some RNG issue?
-    @testset "NUTS tests with heavier tails and skewness" begin
-        K = 5
+@testset "NUTS tests with heavier tails and skewness" begin
+    K = 5
 
-        ℓ = elongate(1.2, StandardMultivariateNormal(K))
-        NUTS_tests(RNG, ℓ, "elongate(1.2, 𝑁)", 1000; p_alert = 1e-5, EBFMI_alert = 0.2)
+    ℓ = elongate(1.2, StandardMultivariateNormal(K))
+    NUTS_tests(RNG, ℓ, "elongate(1.2, 𝑁)", 1000; p_alert = 1e-5, EBFMI_alert = 0.2)
 
-        # this has very nasty tails to we relax requirements a bit
-        ℓ = elongate(1.1, shift(ones(K), StandardMultivariateNormal(K)))
-        NUTS_tests(RNG, ℓ, "skew elongate(1.1, 𝑁)", 10000; τ_alert = 0.1, EBFMI_alert = 0.2)
-    end
+    # this has very nasty tails to we relax requirements a bit
+    ℓ = elongate(1.1, shift(ones(K), StandardMultivariateNormal(K)))
+    NUTS_tests(RNG, ℓ, "skew elongate(1.1, 𝑁)", 10000; τ_alert = 0.1, EBFMI_alert = 0.2)
 end


### PR DESCRIPTION
This PR adds support for Julia 1.6, without adding additional code or special casing. Actually, tests still passed locally after removing the version bound in the tests.

CompatHelper was running with Julia 1.2.0, so I updated it as well.