### PR TITLE
Provide more details when initial stepsize search fails.

### DIFF
--- a/src/stepsize.jl
+++ b/src/stepsize.jl
@@ -179,10 +179,6 @@ function local_acceptance_ratio(H, z)
     end
 end
 
-function find_initial_stepsize(parameters::InitialStepsizeSearch, H, z)
-    find_initial_stepsize(parameters, local_acceptance_ratio(H, z))
-end
-
 """
 $(TYPEDEF)
 

--- a/test/test_hamiltonian.jl
+++ b/test/test_hamiltonian.jl
@@ -1,6 +1,6 @@
 using DynamicHMC: GaussianKineticEnergy, kinetic_energy, ∇kinetic_energy, rand_p,
     Hamiltonian, EvaluatedLogDensity, evaluate_ℓ, PhasePoint, logdensity, leapfrog,
-    calculate_p♯, logdensity, find_initial_stepsize, DynamicHMCError
+    calculate_p♯, logdensity, find_initial_stepsize, DynamicHMCError, local_acceptance_ratio
 
 ####
 #### utility functions
@@ -135,7 +135,7 @@ end
 
     for _ in 1:100
         @unpack H, z = rand_Hz(rand(2:5))
-        ϵ = find_initial_stepsize(InitialStepsizeSearch(), H, z)
+        ϵ = find_initial_stepsize(InitialStepsizeSearch(), local_acceptance_ratio(H, z))
         test_hamiltonian_invariance(H, z, 10, ϵ/100; atol = 0.5)
     end
 end

--- a/test/test_stepsize.jl
+++ b/test/test_stepsize.jl
@@ -4,7 +4,7 @@
 
 using DynamicHMC: find_crossing_stepsize, bisect_stepsize, find_initial_stepsize,
     InitialStepsizeSearch, DualAveraging, initial_adaptation_state, adapt_stepsize,
-    current_ϵ, final_ϵ, FixedStepsize
+    current_ϵ, final_ϵ, FixedStepsize, local_acceptance_ratio
 
 @testset "stepsize general rootfinding" begin
     Δ = 3.0                   # shift exponential so that ϵ = 1 is not in interval
@@ -119,7 +119,7 @@ end
     p = InitialStepsizeSearch()
     for _ in 1:100
         @unpack H, z = rand_Hz(rand(3:5))
-        ϵ = find_initial_stepsize(p, H, z)
+        ϵ = find_initial_stepsize(p, local_acceptance_ratio(H, z))
         logA = logdensity(H, leapfrog(H, z, ϵ)) - logdensity(H, z)
         @test p.a_min ≤ exp(logA) ≤ p.a_max
     end
@@ -129,5 +129,5 @@ end
     p = InitialStepsizeSearch()
     @unpack H, z = rand_Hz(2)
     z = DynamicHMC.PhasePoint(z.Q, [NaN, NaN])
-    @test_throws DynamicHMCError find_initial_stepsize(p, H, z)
+    @test_throws DynamicHMCError find_initial_stepsize(p, local_acceptance_ratio(H, z))
 end


### PR DESCRIPTION
Incidental: remove method that was only used in tests.