### PR TITLE
Simplify stepsize search.

### DIFF
--- a/src/diagnostics.jl
+++ b/src/diagnostics.jl
@@ -9,7 +9,7 @@ export EBFMI, summarize_tree_statistics, explore_log_acceptance_ratios, leapfrog
     InvalidTree, REACHED_MAX_DEPTH, is_divergent
 
 using DynamicHMC: GaussianKineticEnergy, Hamiltonian, evaluate_ℓ, InvalidTree,
-    REACHED_MAX_DEPTH, is_divergent, local_acceptance_ratio, PhasePoint, rand_p, leapfrog,
+    REACHED_MAX_DEPTH, is_divergent, local_log_acceptance_ratio, PhasePoint, rand_p, leapfrog,
     logdensity, MAX_DIRECTIONS_DEPTH
 
 using ArgCheck: @argcheck
@@ -148,7 +148,7 @@ function explore_log_acceptance_ratios(ℓ, q, log2ϵs;
                                        N = 20, ps = [rand_p(rng, κ) for _ in 1:N])
     H = Hamiltonian(κ, ℓ)
     Q = evaluate_ℓ(ℓ, q)
-    As = [local_acceptance_ratio(H, PhasePoint(Q, p)) for p in ps]
+    As = [local_log_acceptance_ratio(H, PhasePoint(Q, p)) for p in ps]
     [A(2.0^log2ϵ) for log2ϵ in log2ϵs, A in As]
 end
 

--- a/src/mcmc.jl
+++ b/src/mcmc.jl
@@ -134,7 +134,7 @@ function warmup(sampling_logdensity, stepsize_search::InitialStepsizeSearch, war
     @argcheck ϵ ≡ nothing "stepsize ϵ manually specified, won't perform initial search"
     z = PhasePoint(Q, rand_p(rng, κ))
     try
-        ϵ = find_initial_stepsize(stepsize_search, local_acceptance_ratio(Hamiltonian(κ, ℓ), z))
+        ϵ = find_initial_stepsize(stepsize_search, local_log_acceptance_ratio(Hamiltonian(κ, ℓ), z))
         report(reporter, "found initial stepsize",
                ϵ = round(ϵ; sigdigits = REPORT_SIGDIGITS))
         nothing, WarmupState(Q, κ, ϵ)

--- a/test/test_hamiltonian.jl
+++ b/test/test_hamiltonian.jl
@@ -1,6 +1,6 @@
 using DynamicHMC: GaussianKineticEnergy, kinetic_energy, ∇kinetic_energy, rand_p,
     Hamiltonian, EvaluatedLogDensity, evaluate_ℓ, PhasePoint, logdensity, leapfrog,
-    calculate_p♯, logdensity, find_initial_stepsize, DynamicHMCError, local_acceptance_ratio
+    calculate_p♯, logdensity, find_initial_stepsize, DynamicHMCError, local_log_acceptance_ratio
 
 ####
 #### utility functions
@@ -135,7 +135,7 @@ end
 
     for _ in 1:100
         @unpack H, z = rand_Hz(rand(2:5))
-        ϵ = find_initial_stepsize(InitialStepsizeSearch(), local_acceptance_ratio(H, z))
+        ϵ = find_initial_stepsize(InitialStepsizeSearch(), local_log_acceptance_ratio(H, z))
         test_hamiltonian_invariance(H, z, 10, ϵ/100; atol = 0.5)
     end
 end


### PR DESCRIPTION
1. use log acceptance ratios, to avoid numerical overflows.

2. revert back to the original NUTS crossing algorithm. Sophisticated bracketing does not buy much, and occasionaly it can lead to step sizes which adapt "too well" to local information and recovering from them takes time.